### PR TITLE
Edit summary mode, user story #12

### DIFF
--- a/src/css/summary.css
+++ b/src/css/summary.css
@@ -2,7 +2,7 @@
   padding: 20px;
 
 }
-.summary h1 {
+.summary .h1 {
   margin-right: 20px;
   display: inline;
 }
@@ -27,7 +27,7 @@ button:hover {
  -o-transition: opacity .2s ease-in-out;
   cursor: pointer;
 }
-textarea, .edit {
+.note, .edit {
   font-family: 'Crimson Text', serif;
   width: 100%;
   color: #95989A;
@@ -36,23 +36,45 @@ textarea, .edit {
   overflow: hidden;
   min-height: 50vh;
 }
-
-textarea::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+.h1 {
+  font-family: 'Crimson Text', serif;
+  color: #1A334F;;
+  font-size: 2em;
+  resize: none;
+  border: none;
+  overflow: hidden;
+}
+.h1, .icon {
+    vertical-align: top;
+}
+.h1::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+  color: #1A334F;
+}
+.h1::-moz-placeholder { /* Firefox 19+ */
+  color: #1A334F;
+}
+.h1:-ms-input-placeholder { /* IE 10+ */
+  color: #1A334F;
+}
+.h1:-moz-placeholder { /* Firefox 18- */
+  color: #1A334F;
+}
+.note::-webkit-input-placeholder { /* Chrome/Opera/Safari */
   color: #BCBDBE;
 }
-textarea::-moz-placeholder { /* Firefox 19+ */
+.note::-moz-placeholder { /* Firefox 19+ */
   color: #BCBDBE;
 }
-textarea:-ms-input-placeholder { /* IE 10+ */
+.note:-ms-input-placeholder { /* IE 10+ */
   color: #BCBDBE;
 }
-textarea:-moz-placeholder { /* Firefox 18- */
+.note:-moz-placeholder { /* Firefox 18- */
   color: #BCBDBE;
 }
-textarea:focus {
+.note:focus, .h1:focus {
   outline: none;
 }
-.summary h1 {
+.summary .h1 {
   font-family: 'Crimson Text', serif;
 }
 

--- a/src/css/summary.css
+++ b/src/css/summary.css
@@ -38,7 +38,7 @@ button:hover {
 }
 .h1 {
   font-family: 'Crimson Text', serif;
-  color: #1A334F;;
+  color: #1A334F;
   font-size: 2em;
   resize: none;
   border: none;
@@ -162,4 +162,35 @@ button:hover {
   .summary {
     padding: 0 20%;
   }
+}
+
+.summary-sentence {
+  color: #1A334F;
+  text-align: left;
+  padding-left: 30px;
+  cursor: pointer;
+}
+.non-summary-sentence {
+  color: #95989A;
+  text-align: left;
+  padding-left: 30px;
+  cursor: pointer;
+}
+
+.summary-sentence:hover::before {
+    background: url("../assets/x-icon.svg") no-repeat;
+}
+.non-summary-sentence:hover::before {
+    background: url("../assets/plus-icon.svg") no-repeat;
+}
+.summary-sentence:hover::before, .non-summary-sentence:hover::before {
+  content: "";
+  width: 20px;
+  height: 20px;
+  position: absolute;
+  margin-left: -31px;
+  cursor: pointer;
+}
+.marginBottom {
+  margin-bottom: 80px;
 }

--- a/src/pages/login/Register.js
+++ b/src/pages/login/Register.js
@@ -2,9 +2,17 @@ import React, { Component } from 'react';
 import '../../css/register.css';
 import headphones from '../../assets/background/white-headphones.svg';
 import apiFetch from '../../utils/api.js';
+import { Redirect } from 'react-router-dom';
 import '../../css/login.css';
 
 class Register extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      redirect: false,
+      error: null
+    }
+  }
   register = (e) => {
     e.preventDefault();
     return apiFetch('createAccount',{
@@ -20,17 +28,18 @@ class Register extends Component {
       })
     }).then((response) => response.json())
         .then((json) => {
-          console.log('response', json);
           if(json.success === false) {
-              console.log('error', json.message);
+              this.setState({ error: json.error });
           }
           else {
-            console.log('register success json',json);
+            this.setState({ redirect: true });
           }
         });
   }
   render() {
-    const { error } = this.props;
+    if (this.state.redirect === true) {
+      return (<Redirect to="/login"/>);
+    }
     return (
       <div className="page bgorange">
         <div className="title logo">
@@ -41,7 +50,7 @@ class Register extends Component {
         <div className = "registerbox">
           <form onSubmit={this.register}>
             <div className = "errorClass">
-              {error ? `Error=${error}` : null}
+              {this.state.error ? `Error=${this.state.error}` : null}
             </div>
             <label htmlFor="fname">First Name</label>
             <input type="text" name="fname" required />

--- a/src/pages/summary/EditSummary.js
+++ b/src/pages/summary/EditSummary.js
@@ -1,16 +1,30 @@
-import React, { Component } from 'react';
-import apiFetch from '../../utils/api.js';
+import React from 'react';
+import '../../css/summary.css';
 
-class EditSummary extends Component {
-  constructor(props) {
-    super(props);
+const EditSummary = ({ response, updateResponse, setError, brevity }) => {
+  const deleteSentenceFromSummary = (index) => {
+    console.log('index', index);
+    updateResponse(index, response.length);
+  };
+  const addSentenceToSummary = (index) => {
+    updateResponse(index, -1);
+  };
+  const sentences = [];
+  console.log('response', response);
+  if (response) {
+    const summaryCount = Math.floor(brevity * (1/100) * response.length);
+      response.forEach((sentence, index) => {
+        console.log('index', index);
+      if (sentence[1] <= summaryCount) {
+        sentences.push(<p className="summary-sentence" onClick={() => deleteSentenceFromSummary(index)} key={`Sentence: ${index}: ${sentence[0]}`}>{sentence[0]}</p>);
+      } else {
+        sentences.push(<p className="non-summary-sentence" onClick={() => addSentenceToSummary(index)} key={`Sentence: ${index}: ${sentence[0]}`}>{sentence[0]}</p>);
+      }
+    });
+  } else {
+    setError('You can only edit summarized text!');
   }
-  render() {
-    return (
-      <div>Edit Summary</div>
-    );
-  }
-
+  return <div className="marginBottom">{sentences}</div>;
 }
 
 export default EditSummary;

--- a/src/pages/summary/EditSummary.js
+++ b/src/pages/summary/EditSummary.js
@@ -1,0 +1,16 @@
+import React, { Component } from 'react';
+import apiFetch from '../../utils/api.js';
+
+class EditSummary extends Component {
+  constructor(props) {
+    super(props);
+  }
+  render() {
+    return (
+      <div>Edit Summary</div>
+    );
+  }
+
+}
+
+export default EditSummary;

--- a/src/pages/summary/index.js
+++ b/src/pages/summary/index.js
@@ -6,6 +6,7 @@ import apiFetch from '../../utils/api.js';
 import '../../css/summary.css';
 import edit_icon_orange from '../../assets/pencil-icon-orange.svg';
 import Loader from '../components/Loader';
+import EditSummary from './EditSummary';
 
 class Summary extends Component {
   static propTypes = {
@@ -20,10 +21,13 @@ class Summary extends Component {
       response: {},
       brevity: 50,
       isWaiting: false,
-      toggleEdit: false,
+      editMode: false,
       sentenceCount: null,
       text: '',
-      receivedSummary: false
+      receivedSummary: false,
+      error: null,
+      title: null,
+      editTitle: false
     };
   }
   updateSummary = () => {
@@ -64,7 +68,7 @@ class Summary extends Component {
         if (json.success === false) {
           console.log('error', json.error);
           this.setState({
-            toggleEdit: false,
+            editMode: false,
             error: "json.error"
           });
         }
@@ -87,6 +91,9 @@ class Summary extends Component {
   }
   onEdit = (e) => {
     this.setState({ text: e.target.value });
+  }
+  onEditTitle = (e) => {
+    this.setState({ title: e.target.value });
   }
   changeBrevity = (e) => {
     this.setState({
@@ -120,12 +127,32 @@ class Summary extends Component {
           // call funtion to send data to page
           console.log('success',json);
           this.setState({
-            toggleEdit: false
+            editMode: false
           });
           console.log('response', json);
           // this.updateSummary();
         }
       });
+  }
+  setError = (error) => {
+    this.setState({
+      error
+    });
+  }
+  toggleEdit = () => {
+    if (this.state.receivedSummary === true) {
+      this.setState({
+        editMode: !this.state.editMode
+      });
+    } else {
+      this.setError("You can only edit summarized text!");
+      window.setTimeout(function() { this.setError(null); }.bind(this), 4000);
+    }
+  }
+  toggleEditTitle = () => {
+    this.setState({
+      editTitle: true
+    });
   }
   render() {
     const { cookies } = this.props;
@@ -141,12 +168,13 @@ class Summary extends Component {
       <div className="summary">
       {this.state.isWaiting ? <Loader/> : null}
       <form onSubmit={this.summarize}>
-        <h1>Title</h1>
-        <button className="icon orange"><img src={edit_icon_orange} alt="edit"/></button>
-        {this.state.toggleEdit ?
-          {sentences}
+        <textarea className="h1" name="textarea" placeholder="Enter a Title..." value={this.state.title} onChange={this.onEditTitle} onKeyUp={this.handleKeyUp} />
+        <button className="icon orange" onClick={this.toggleEdit}><img src={edit_icon_orange} alt="edit"/></button>
+        {this.state.error ? <p>{this.state.error}</p> : null}
+        {this.state.editMode ?
+          <EditSummary sentences={this.state.sentences} />
           :
-          <textarea name="textarea" placeholder="Start taking notes..." onKeyUp={this.handleKeyUp} value={this.state.text} onChange={this.onEdit} id="summary"/>
+          <textarea className="note" name="textarea" placeholder="Start taking notes..." onKeyUp={this.handleKeyUp} value={this.state.text} onChange={this.onEdit} id="summary"/>
         }
         <button className="fixed" type="submit">Summarize</button>
         <button onClick={this.saveSummary} className="fixed save">Save</button>

--- a/src/pages/summary/index.js
+++ b/src/pages/summary/index.js
@@ -39,9 +39,6 @@ class Summary extends Component {
       }
       sentences.push(sentence[0]);
     });
-    console.log('sentences', sentences.join(' '));
-    console.log('summary', summary.join(' '));
-
     this.setState({
       summary: summary.join(' '),
       text: summary.join(' ')

--- a/src/pages/summary/index.js
+++ b/src/pages/summary/index.js
@@ -27,7 +27,8 @@ class Summary extends Component {
       receivedSummary: false,
       error: null,
       title: null,
-      editTitle: false
+      editTitle: false,
+      wait: false,
     };
   }
   updateSummary = () => {
@@ -49,10 +50,10 @@ class Summary extends Component {
     });
   }
   summarize = (e) => {
-    this.setState({
-      isWaiting: true
-    });
     e.preventDefault();
+    this.setState({
+      wait: true
+    });
     e.persist();
     return apiFetch('summarizertext', {
       headers: {
@@ -78,7 +79,7 @@ class Summary extends Component {
           this.setState({
             response: json.text,
             receivedSummary: true,
-            isWaiting: false
+            wait: false
           });
           console.log('response', json);
           this.updateSummary();
@@ -122,6 +123,8 @@ class Summary extends Component {
     ).then((json) => {
         if (json.success === false) {
             console.log('error', json.error);
+            this.setError("Your summary was not saved!");
+            window.setTimeout(function() { this.setError(null); }.bind(this), 4000);
         }
         else {
           // call funtion to send data to page
@@ -129,6 +132,9 @@ class Summary extends Component {
           this.setState({
             editMode: false
           });
+          this.setError("Your summary was successfully saved!");
+          window.setTimeout(function() { this.setError(null); }.bind(this), 4000);
+
           console.log('response', json);
           // this.updateSummary();
         }
@@ -139,10 +145,15 @@ class Summary extends Component {
       error
     });
   }
-  toggleEdit = () => {
+  toggleEditMode = (e) => {
+    e.preventDefault( );
     if (this.state.receivedSummary === true) {
       this.setState({
         editMode: !this.state.editMode
+      });
+    } else if (this.state.editMode === true) {
+      this.setState({
+        editMode: false
       });
     } else {
       this.setError("You can only edit summarized text!");
@@ -166,10 +177,10 @@ class Summary extends Component {
     });
     return (
       <div className="summary">
-      {this.state.isWaiting ? <Loader/> : null}
-      <form onSubmit={this.summarize}>
+      {this.state.wait ? <Loader/> : null}
+      <form onSubmit={(e) => this.summarize(e)}>
         <textarea className="h1" name="textarea" placeholder="Enter a Title..." value={this.state.title} onChange={this.onEditTitle} onKeyUp={this.handleKeyUp} />
-        <button className="icon orange" onClick={this.toggleEdit}><img src={edit_icon_orange} alt="edit"/></button>
+        <button className="icon orange" onClick={this.toggleEditMode}><img src={edit_icon_orange} alt="edit"/></button>
         {this.state.error ? <p>{this.state.error}</p> : null}
         {this.state.editMode ?
           <EditSummary sentences={this.state.sentences} />


### PR DESCRIPTION
## Goal 
*Create an edit summary mode, only after the user summaries their note*


## Tasks
  - [x] Parse JSON response into sentences that
render blocks you can hide and add back
  - [x] Add an icon when you would like to add
a sentence before, on hover
  - [x] Add icon when you would like to delete a
sentence, on hover
  - [x] Implement the functionality to keep track
of hidden sentences based on brevity
  - [x] Style the add and subtract buttons